### PR TITLE
fixed jdk8 (1.8.0_05-b13) install on Mac OS X (10.10.2)

### DIFF
--- a/uispec4j/src/main/java-jdk8/org/uispec4j/interception/toolkit/ToolkitDelegate.java
+++ b/uispec4j/src/main/java-jdk8/org/uispec4j/interception/toolkit/ToolkitDelegate.java
@@ -128,7 +128,42 @@ public abstract class ToolkitDelegate extends SunToolkit implements ComponentFac
   }
 
   public DataTransferer getDataTransferer() {
-     return asSun().getDataTransferer();
+    /*
+     * The SunToolkit#getDataTransferer() method does not appear to exist in
+     * JDK8 (at least on Mac OS X 10.10.2), but there is a
+     * SunToolkit#getDataTransfererClassName() method that can be used
+     * instead.
+     */
+    SunToolkit sunToolkit = asSun();
+
+    try {
+      java.lang.reflect.Method getDataTransferer = sunToolkit.getClass()
+        .getMethod("getDataTransferer", (Class<?>[]) null);
+
+      return (DataTransferer)
+        getDataTransferer.invoke(sunToolkit, (Object[]) null);
+    } catch (NoSuchMethodException ex) {
+      /* expected on JDK8 on Mac OS X 10.10.2 (others?) */
+    } catch (ReflectiveOperationException ex) {
+      throw new UnsupportedOperationException(
+        "unable to get a DataTransferer instance from the underlying Toolkit",
+        ex);
+    }
+
+    try {
+      java.lang.reflect.Method getDataTransfererClassName =
+        sunToolkit.getClass()
+          .getMethod("getDataTransfererClassName", (Class<?>[]) null);
+      String dataTransfererClassName = (String)
+        getDataTransfererClassName.invoke(sunToolkit, (Object[]) null);
+
+      return (DataTransferer)
+        Class.forName(dataTransfererClassName).newInstance();
+    } catch (ReflectiveOperationException ex) {
+      throw new UnsupportedOperationException(
+        "unable to get a DataTransferer instance from the underlying Toolkit",
+        ex);
+    }
   }
 
   public FontMetrics getFontMetrics(Font font) {


### PR DESCRIPTION
I tried to run "mvn -Pjdk8 -Dgpg.skip=true clean install" from the docs so that I could use 2.5-SNAPSHOT after discovering that my tests no longer ran on one of my projects.

However, this failed with:
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:2.3.2:compile (default-compile) on project uispec4j: Compilation failure
[ERROR] /private/tmp/UISpec4J/uispec4j/src/main/java-jdk8/org/uispec4j/interception/toolkit/ToolkitDelegate.java:[131,19] error: cannot find symbol

Looking into this, I discovered that the SunToolkit#getDataTransferer() method being called from ToolkitDelegate#getDataTransferer() does not exist. I did find a similar method, SunToolkit#getDataTransfererClassName(), and was able to finally get the JDK8 install for UISpec4J working successfully with the change in this pull request.

Thanks.