### PR TITLE
Avoid JVM crash by ensuring we don't create a second XToolkit Instance

### DIFF
--- a/uispec4j/src/main/java/org/uispec4j/UISpec4J.java
+++ b/uispec4j/src/main/java/org/uispec4j/UISpec4J.java
@@ -34,9 +34,11 @@ public class UISpec4J {
 
   private static void initToolkit() {
     try {
+      Toolkit underlyingToolkit = Toolkit.getDefaultToolkit();
+
       Field toolkitField = Toolkit.class.getDeclaredField("toolkit");
       toolkitField.setAccessible(true);
-      toolkitField.set(null, new UISpecToolkit());
+      toolkitField.set(null, new UISpecToolkit(underlyingToolkit));
     }
     catch (Exception e) {
       throw new RuntimeException("Unable to initialize toolkit for interception.", e);

--- a/uispec4j/src/main/java/org/uispec4j/interception/toolkit/UISpecToolkit.java
+++ b/uispec4j/src/main/java/org/uispec4j/interception/toolkit/UISpecToolkit.java
@@ -21,6 +21,11 @@ public class UISpecToolkit extends ToolkitDelegate {
   private static String awtToolkit;
 
   public UISpecToolkit() {
+    this(null);
+  }
+
+  public UISpecToolkit(Toolkit underlyingToolkit) {
+    this.underlyingToolkit = underlyingToolkit;
     setUp();
   }
 


### PR DESCRIPTION
See the sort of crash was reported here: https://bugs.openjdk.java.net/browse/JDK-8146230  (See https://bugs.openjdk.java.net/browse/JDK-8146230?focusedCommentId=13883304&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13883304 for a breakdown)

It looks like some effort was put into fixing it (https://marc.info/?t=146780444100003).  That effort stalled with the question of how there's concurrent execution to begin with.  In the trace in JDK-8146230, you can see that there are two "AWT-XAWT" threads.  That thread is created here (https://github.com/openjdk/jdk/blob/dd570ee6c85ed6f6093755efc17ce21258c538f9/src/java.desktop/unix/classes/sun/awt/X11/XToolkit.java#L434) when an XToolkit instance is created.  Thing is, XToolkit is supposed to only be created via Toolkit.getDefaultToolkit() (https://github.com/openjdk/jdk/blob/dd570ee6c85ed6f6093755efc17ce21258c538f9/src/java.desktop/share/classes/java/awt/Toolkit.java#L580), which is synchronized to only do it once.

UISpec4J breaks the assumptions that only one XToolkit instance exists by overwriting the current AWT toolkit via reflection (https://github.com/UISpec4J/UISpec4J/blob/fdc0b420cabb36134dd99830434c8fd2d05d508d/uispec4j/src/main/java/org/uispec4j/UISpec4J.java#L37) and then creating its own instance of the toolkit (https://github.com/UISpec4J/UISpec4J/blob/fdc0b420cabb36134dd99830434c8fd2d05d508d/uispec4j/src/main/java/org/uispec4j/interception/toolkit/UISpecToolkit.java#L134).

This change ensures we use an existing XToolkit if one exists.